### PR TITLE
Feature/deich 748 search metrics

### DIFF
--- a/docker-compose/common.yml
+++ b/docker-compose/common.yml
@@ -11,6 +11,7 @@ volumes:
   koha_mysql_data: {}
   elasticsearch_data: {}
   fuseki_data: {}
+  overview_data: {}
 
 services:
   koha:
@@ -223,6 +224,8 @@ services:
       KOHA_VERSION: "${KOHA_IMAGE_TAG:-0}"
       GITREF: "${GITREF:-0}"
       BUILD_TAG: "${BUILD_TAG:-0}"
+    volumes:
+      - "overview_data:/etc/nginx/html/shared"
     logging:
       driver: "json-file"
       options:

--- a/docker-compose/prod.yml
+++ b/docker-compose/prod.yml
@@ -155,5 +155,8 @@ services:
     environment:
       METRICS_INTERVAL: 600
       GRAPH_HOST: metrics
+      METRICS_HOST: "${METRICS_HOST:-localhost}"
+      METRICS_DOCKER: "${METRICS_DOCKER:-search_metrics}"
+      METRICS_ENV: "${METRICS_ENV:-dev}"
     volumes:
       - "overview_data:/app/html"

--- a/docker-compose/prod.yml
+++ b/docker-compose/prod.yml
@@ -143,3 +143,17 @@ services:
   overview:
     logging:
       driver: "journald"
+
+  search_metrics:
+    container_name: search_metrics
+    image: digibib/search_metrics:0ef9ab2b5569df60b11a4c7f1f40c4ec88f1c730
+    networks:
+      - backend
+    extra_hosts:
+      - "metrics:10.172.2.97"
+      - "sok.deichman.no:10.172.2.6"
+    environment:
+      METRICS_INTERVAL: 600
+      GRAPH_HOST: metrics
+    volumes:
+      - "overview_data:/app/html"

--- a/redef/overview/files/overview.tpl
+++ b/redef/overview/files/overview.tpl
@@ -136,7 +136,7 @@
             <a class="bg-yellow" href="http://${HOST}:${KOHA_INTRA_PORT}/cgi-bin/koha/circ/returns.pl"><h3>Skranke innlevering</h3></a>
         </div>
         <div class="col panel bg-grey">
-            <a class="bg-yellow"  href="http://${HOST}:${KOHA_INTRA_PORT}/cgi-bin/koha/members/members-home.pl"><h3>Finn bruker</h3></a>
+            <a class="bg-yellow" href="http://${HOST}:${KOHA_INTRA_PORT}/cgi-bin/koha/members/members-home.pl"><h3>Finn bruker</h3></a>
         </div>
         <div class="col panel bg-grey">
             <h3>Prege (TODO)</h3>
@@ -161,6 +161,12 @@
             <a class="bg-grey" href="http://wiki.deichman.no/index.php/Bibliotekfaglige_lenker"><h3>Bibliotekfaglige lenker</h3></a>
         </div>
     </div>
+    <div class="row">
+        <div class="col panel bg-pink">
+            <a class="bg-grey" href="shared/results.html"><h3>Resultat søketester</h3></a>
+        </div>
+    </div>
+    <div class="row"><h1>Nyttige verktøy</h1></div>
     <h2>Versjonsinformasjon</h2>
     <p><strong>GITREF:</strong> ${GITREF}</p>
 </div>


### PR DESCRIPTION
Adds a container to prod.yml, search_metrics that connects dots between search items in google docs, metrics, and a static report at the overview page (saved in a shared folder volume).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digibib/ls.ext/57)
<!-- Reviewable:end -->
